### PR TITLE
Hide Failed to export spans in Nessie Catalog

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,8 @@ services:
       iceberg-nessie-flink-net:
     ports:
       - 19120:19120
+    environment:
+      - quarkus.otel.sdk.disabled=true      
   # Minio Storage Server
   storage:
     image: minio/minio


### PR DESCRIPTION
for example:

catalog  | 2023-09-29 11:23:28,020 SEVERE [io.ope.exp.int.grp.OkHttpGrpcExporter] (OkHttp http://localhost:4317/...) Failed to export spans. The request could not be executed. Full error message: Failed to connect to localhost/127.0.0.1:4317

<img width="1254" alt="Screenshot 2023-09-29 at 14 26 49" src="https://github.com/developer-advocacy-dremio/flink-iceberg-nessie-environment/assets/1549046/5a312506-6c83-43e0-8150-4729442672ec">
